### PR TITLE
Pin `conda-build` to match our current pinnings

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-forge-build-setup
-  version: 1.0.0
+  version: 1.0.1
 
 build:
   number: 0
@@ -12,7 +12,10 @@ build:
 
 requirements:
   run:
-    - conda-build
+    - conda-build         # [linux]
+    - conda-build 1.20.0  # [osx]
+    - conda-build 1.20.0  # [win64 and py34]
+    - conda-build         # [win and not (win64 and py34)]
     - jinja2
     - anaconda-client
 


### PR DESCRIPTION
We will probably remove this soon. However, my focus here is that we deal with one problem at a time.
1. Start using this package in `staged-recipes`.
2. Handle any fixes to this package.
3. After a trial period in `staged-recipes`, add this to `conda-smithy`.
4. Unpin and possibly repin `conda-build` as needed.

So, that we can focus on the transition to this package. I would like us to table the `conda-build` pinning discussion initially so we can focus on problems caused by the transition in isolation. Once we are comfortable with how this package is used, we can play with unpinning `conda-build`. As a result, I'm pinning `conda-build` here to match what it is `conda-smithy` and `staged-recipes` so that is not a variable.
