### PR TITLE
FIX: downgrade conda-build to 1.20.0 on windows builds 

### DIFF
--- a/recipe/run_conda_forge_build_setup_win
+++ b/recipe/run_conda_forge_build_setup_win
@@ -9,6 +9,7 @@ conda install -n root --yes --quiet jinja2 anaconda-client
 # Workaround for Python 3.4 and x64 bug in latest conda-build.
 # FIXME: Remove once there is a release that fixes the upstream issue
 # ( https://github.com/conda/conda-build/issues/895 ).
-if "%TARGET_ARCH%" == "x64" if "%CONDA_PY%" == "34" conda install -n root --yes --quiet conda-build=1.20.0
+# if "%TARGET_ARCH%" == "x64" if "%CONDA_PY%" == "34" conda install -n root --yes --quiet conda-build=1.20.0
 
-conda info
+# see https://github.com/conda-forge/staged-recipes/pull/750#issuecomment-225165530
+conda install -n root --yes --quiet conda-build=1.20.0

--- a/recipe/run_conda_forge_build_setup_win
+++ b/recipe/run_conda_forge_build_setup_win
@@ -6,11 +6,6 @@ conda config --set add_pip_as_python_dependency false
 conda update -n root --yes --quiet conda conda-build
 conda install -n root --yes --quiet jinja2 anaconda-client
 
-# Workaround for Python 3.4 and x64 bug in latest conda-build.
-# FIXME: Remove once there is a release that fixes the upstream issue
-# ( https://github.com/conda/conda-build/issues/895 ).
-# if "%TARGET_ARCH%" == "x64" if "%CONDA_PY%" == "34" conda install -n root --yes --quiet conda-build=1.20.0
-
 # see https://github.com/conda-forge/staged-recipes/pull/750#issuecomment-225165530
 conda install -n root --yes --quiet conda-build=1.20.0
 

--- a/recipe/run_conda_forge_build_setup_win
+++ b/recipe/run_conda_forge_build_setup_win
@@ -13,3 +13,5 @@ conda install -n root --yes --quiet jinja2 anaconda-client
 
 # see https://github.com/conda-forge/staged-recipes/pull/750#issuecomment-225165530
 conda install -n root --yes --quiet conda-build=1.20.0
+
+conda info


### PR DESCRIPTION
skip: True # [win] isn't working with latest conda-build
see conda-forge/staged-recipes#750 (comment)
