### PR TITLE
downgrade conda-build to 1.20.1

### DIFF
--- a/recipe/run_conda_forge_build_setup_win
+++ b/recipe/run_conda_forge_build_setup_win
@@ -7,6 +7,6 @@ conda update -n root --yes --quiet conda conda-build
 conda install -n root --yes --quiet jinja2 anaconda-client
 
 # see https://github.com/conda-forge/staged-recipes/pull/750#issuecomment-225165530
-conda install -n root --yes --quiet conda-build=1.20.2
+conda install -n root --yes --quiet conda-build=1.20.1
 
 conda info


### PR DESCRIPTION
1.20.2 did not work. Let's try 1.20.1 (no need to bump the build number as I removed the bad builds. Bad practice, but I don't want these to propagate beyond my tests here.)
