### PR TITLE
Cannot use conda-build 1.20.1 PY34Win64

### DIFF
--- a/recipe/run_conda_forge_build_setup_win
+++ b/recipe/run_conda_forge_build_setup_win
@@ -6,7 +6,12 @@ conda config --set add_pip_as_python_dependency false
 conda update -n root --yes --quiet conda conda-build
 conda install -n root --yes --quiet jinja2 anaconda-client
 
-# see https://github.com/conda-forge/staged-recipes/pull/750#issuecomment-225165530
+# conda-build-all is not ready for latest conda-build.
+# See https://github.com/conda-forge/staged-recipes/pull/750#issuecomment-225165530
 conda install -n root --yes --quiet conda-build=1.20.1
+
+# Workaround for Python 3.4 and x64 bug in latest conda-build.
+# FIXME: Remove once there is a release that fixes the upstream issue
+# ( https://github.com/conda/conda-build/issues/895 ).
 if "%TARGET_ARCH%" == "x64" if "%CONDA_PY%" == "34" conda install -n root --yes --quiet conda-build=1.20.0
 conda info

--- a/recipe/run_conda_forge_build_setup_win
+++ b/recipe/run_conda_forge_build_setup_win
@@ -8,5 +8,5 @@ conda install -n root --yes --quiet jinja2 anaconda-client
 
 # see https://github.com/conda-forge/staged-recipes/pull/750#issuecomment-225165530
 conda install -n root --yes --quiet conda-build=1.20.1
-
+if "%TARGET_ARCH%" == "x64" if "%CONDA_PY%" == "34" conda install -n root --yes --quiet conda-build=1.20.0
 conda info


### PR DESCRIPTION
Use conda-build `1.20.1` everywhere but `PY34` and `Win64`.
