### PR TITLE
Drop conda-build pinning on OS X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ install:
 
       conda config --set show_channel_urls true
       conda update --yes conda
-      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
+      conda install --yes conda-build jinja2 anaconda-client
       conda config --add channels conda-forge
       
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-forge-build-setup
-  version: 2.2.2
+  version: 2.2.3
 
 build:
   number: 0

--- a/recipe/run_conda_forge_build_setup_osx
+++ b/recipe/run_conda_forge_build_setup_osx
@@ -12,9 +12,5 @@ conda config --set add_pip_as_python_dependency false
 conda update -n root --yes --quiet conda conda-build
 conda install -n root --yes --quiet jinja2 anaconda-client
 
-# Workaround an encoding bug in conda-build 1.20.1 when fixing shebangs.
-# See this issue ( https://github.com/conda/conda-build/issues/889 ).
-conda install -n root --yes --quiet conda-build=1.20.0
-
 conda info
 conda config --get


### PR DESCRIPTION
This pinning is starting to have some huge drawbacks. See this issue ( https://github.com/conda-forge/hdf5-feedstock/issues/23 ). Basically, as we are using newer versions of `conda` and `conda-env` we have symlinks to `activate`, `deactivate`, and `conda` in each environment. The most recent `conda-build` 1.21.0 knows to ignore these files. However, `conda-build` 1.20.0 does not know about this changes so sees these new files added and bundles them up with the package. The result is a mess that no one can install.

cc @msarahan @gillins
