### PR TITLE
Remove conda-build pinning

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-forge-build-setup
-  version: 2.2.1
+  version: 2.2.2
 
 build:
   number: 0

--- a/recipe/run_conda_forge_build_setup_win
+++ b/recipe/run_conda_forge_build_setup_win
@@ -6,10 +6,6 @@ conda config --set add_pip_as_python_dependency false
 conda update -n root --yes --quiet conda conda-build
 conda install -n root --yes --quiet jinja2 anaconda-client
 
-:: conda-build-all is not ready for latest conda-build.
-:: See https://github.com/conda-forge/staged-recipes/pull/750#issuecomment-225165530
-conda install -n root --yes --quiet conda-build=1.20.1
-
 :: Workaround for Python 3.4 and x64 bug in latest conda-build.
 :: FIXME: Remove once there is a release that fixes the upstream issue
 :: ( https://github.com/conda/conda-build/issues/895 ).


### PR DESCRIPTION
This was initially added to workaround an issue with `conda-build-all` and `conda-build` having an API disagreement. It was added in PR ( https://github.com/conda-forge/conda-forge-build-setup-feedstock/pull/7 ) (though tweaked with later PR iterations). The issue raised with `conda-build-all` ( https://github.com/SciTools/conda-build-all/issues/41 ) appears to be resolved by PR ( https://github.com/SciTools/conda-build-all/pull/43 ) and released in version `0.13.1`.

As a result, I think we can safely remove the pinning here, but it would be nice to get some kind of confirmation. Until we get that I have marked this as WIP.

cc @ocefpaf @kmuehlbauer @msarahan @pelson
