### PR TITLE
Remove MAKEFLAGS

### DIFF
--- a/recipe/run_conda_forge_build_setup_linux
+++ b/recipe/run_conda_forge_build_setup_linux
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-# 2 cores are available on CircleCI workers: https://discuss.circleci.com/t/what-runs-on-the-node-container-by-default/1443
-# MAKEFLAGS is passed through conda build: https://github.com/conda/conda-build/pull/917
-export MAKEFLAGS="-j2 ${MAKEFLAGS}"
-
 export PYTHONUNBUFFERED=1
 
 conda config --set show_channel_urls true

--- a/recipe/run_conda_forge_build_setup_osx
+++ b/recipe/run_conda_forge_build_setup_osx
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-# 1 core available on Travis CI OS X workers: https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments
-# MAKEFLAGS is passed through conda build: https://github.com/conda/conda-build/pull/917
-export MAKEFLAGS="-j1 ${MAKEFLAGS}"
-
 export PYTHONUNBUFFERED=1
 
 conda config --set show_channel_urls true


### PR DESCRIPTION
Setting `MAKEFLAGS` by default interferes with the builds and it is not always desired. IMO these should be set in the `build.sh` explicitly.

See [here](https://github.com/conda-forge/staged-recipes/pull/810/files#diff-184b8de768ec3b5604f175db2c6fba5eR11) for an example.

Ping @pelson this particular flag bring the same danger as the `toolchain`. Also, if such a flags is really needed to be set by default, I recommend that it lives in the `toolchain` rather than this setup. That way it goes together with the rest of the build flags making it easier to find and debug issues.

@msarahan what is your opinion on having flags set by default?
