### PR TITLE
Fix conda build OS X install

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-forge-build-setup
-  version: 2.2.3
+  version: 2.2.4
 
 build:
   number: 0

--- a/recipe/run_conda_forge_build_setup_osx
+++ b/recipe/run_conda_forge_build_setup_osx
@@ -9,8 +9,8 @@ export PYTHONUNBUFFERED=1
 conda config --set show_channel_urls true
 conda config --set add_pip_as_python_dependency false
 
-conda update -n root --yes --quiet conda conda-build
-conda install -n root --yes --quiet jinja2 anaconda-client
+conda update -n root --yes --quiet conda
+conda install -n root --yes --quiet jinja2 conda-build anaconda-client
 
 conda info
 conda config --get


### PR DESCRIPTION
Follow-up on PR ( https://github.com/conda-forge/conda-forge-build-setup-feedstock/pull/14 ).

Appears we need the `conda-build` install in the install line. :facepalm:

cc @pelson
