### PR TITLE
Drop conda-build pin on Windows Python 3.4 64-bit

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-forge-build-setup
-  version: 2.2.4
+  version: 2.2.5
 
 build:
   number: 0

--- a/recipe/run_conda_forge_build_setup_win
+++ b/recipe/run_conda_forge_build_setup_win
@@ -6,9 +6,5 @@ conda config --set add_pip_as_python_dependency false
 conda update -n root --yes --quiet conda
 conda install -n root --yes --quiet jinja2 conda-build anaconda-client
 
-:: Workaround for Python 3.4 and x64 bug in latest conda-build.
-:: FIXME: Remove once there is a release that fixes the upstream issue
-:: ( https://github.com/conda/conda-build/issues/895 ).
-if "%TARGET_ARCH%" == "x64" if "%CONDA_PY%" == "34" conda install -n root --yes --quiet conda-build=1.20.0
 conda info
 conda config --get

--- a/recipe/run_conda_forge_build_setup_win
+++ b/recipe/run_conda_forge_build_setup_win
@@ -3,8 +3,8 @@ set PYTHONUNBUFFERED=1
 conda config --set show_channel_urls true
 conda config --set add_pip_as_python_dependency false
 
-conda update -n root --yes --quiet conda conda-build
-conda install -n root --yes --quiet jinja2 anaconda-client
+conda update -n root --yes --quiet conda
+conda install -n root --yes --quiet jinja2 conda-build anaconda-client
 
 :: Workaround for Python 3.4 and x64 bug in latest conda-build.
 :: FIXME: Remove once there is a release that fixes the upstream issue


### PR DESCRIPTION
At this point, it seems that this pinning is doing more harm than good. I'm proposing that we drop the `conda-build` Windows Python 3.4 64-bit pinning. FWICT the upstream issue has been solved. Also, it seems to be causing failures that don't otherwise seem to exist.

cc @pelson @msarahan @patricksnape @gillins
