### PR TITLE
Check index for built distributions

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-forge-build-setup
-  version: 3.1.0
+  version: 3.1.1
 
 build:
   number: 0


### PR DESCRIPTION
Hopefully 🍀 ...

Fixes https://github.com/conda-forge/conda-smithy/issues/270
Fixes https://github.com/Anaconda-Platform/support/issues/60
Closes https://github.com/conda-forge/conda-smithy/pull/273 (moved here)

As we were requesting a list of all files (easily in the 1000s) from the `conda-forge` channel, this was likely slamming the API to process all of this. As this takes a fair bit of time, it was resulting in request timeouts. Thus when the request timed out this caused uploads to fail.

This borrows from @mwcraig's PR ( https://github.com/SciTools/conda-build-all/pull/28 ) to switch to using the index. Unlike asking for the file list from the API, asking for the index should be a near immediate operation. This is because anaconda.org and conda were designed cleverly to ensure the index exists as a separate file from the packages. As a result, we should be able to just download this JSON file (the index) and check against that instead.

Would really appreciate feedback from @bollwyvl and @dsludwig to see if this will solve our issues.
