### PR TITLE
Make sure Linux has `upload_or_check_non_existence`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-forge-build-setup
-  version: 3.2.0
+  version: 3.3.0
 
 build:
   number: 0
@@ -11,12 +11,14 @@ build:
     - cp "${RECIPE_DIR}/run_conda_forge_build_setup_osx" "${PREFIX}/bin/run_conda_forge_build_setup"                     # [osx]
     - cp "${RECIPE_DIR}/run_conda_forge_build_setup_linux" "${PREFIX}/bin/run_conda_forge_build_setup"                   # [linux]
     - COPY "%RECIPE_DIR%\\upload_or_check_non_existence.py" "%SCRIPTS%\\upload_or_check_non_existence.py"                # [win]
-    - cp "${RECIPE_DIR}/upload_or_check_non_existence.py" "${PREFIX}/bin/upload_or_check_non_existence.py"               # [osx]
+    - cp "${RECIPE_DIR}/upload_or_check_non_existence.py" "${PREFIX}/bin/upload_or_check_non_existence"                  # [unix]
 
 test:
   commands:
     - if not exist "%SCRIPTS%\\run_conda_forge_build_setup.bat" exit 1                                                   # [win]
     - test -f "${PREFIX}/bin/run_conda_forge_build_setup"                                                                # [unix]
+    - if not exist "%SCRIPTS%\\upload_or_check_non_existence.py" exit 1                                                  # [win]
+    - test -f "${PREFIX}/bin/upload_or_check_non_existence"                                                              # [unix]
 
 about:
   home: https://github.com/conda-forge/conda-forge-build-setup-feedstock


### PR DESCRIPTION
Makes sure Linux has `upload_or_check_non_existence`. Also adds some tests to make sure the script is in place on all platforms.
