### PR TITLE
Repin `conda-build` to `1`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-forge-build-setup
-  version: 3.4.0
+  version: 3.4.1
 
 build:
   number: 0

--- a/recipe/run_conda_forge_build_setup_linux
+++ b/recipe/run_conda_forge_build_setup_linux
@@ -12,5 +12,8 @@ conda config --set add_pip_as_python_dependency false
 conda update -n root --yes --quiet conda conda-build
 conda install -n root --yes --quiet jinja2 anaconda-client
 
+# KLUDGE to work around changes in conda-build 2.0.0
+conda install -n root --yes --quiet conda-build=1
+
 conda info
 conda config --get

--- a/recipe/run_conda_forge_build_setup_osx
+++ b/recipe/run_conda_forge_build_setup_osx
@@ -12,5 +12,8 @@ conda config --set add_pip_as_python_dependency false
 conda update -n root --yes --quiet conda
 conda install -n root --yes --quiet jinja2 conda-build anaconda-client
 
+# KLUDGE to work around changes in conda-build 2.0.0
+conda install -n root --yes --quiet conda-build=1
+
 conda info
 conda config --get

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -11,5 +11,8 @@ conda config --set add_pip_as_python_dependency false
 conda update -n root --yes --quiet conda
 conda install -n root --yes --quiet jinja2 conda-build anaconda-client
 
+:: KLUDGE to work around changes in conda-build 2.0.0
+conda install -n root --yes --quiet conda-build=1
+
 conda info
 conda config --get


### PR DESCRIPTION
Re-adds the `conda-build` version `1` pinning. Thus reverting commit ( https://github.com/conda-forge/conda-forge-build-setup-feedstock/commit/df4c69eb44baf948c6408f2ae4cf7bfebfaea87c ).
