### PR TITLE
Use conda-build 2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-forge-build-setup
-  version: 3.4.2
+  version: 4.0.0
 
 build:
   number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -28,5 +28,6 @@ about:
 extra:
   recipe-maintainers:
     - jakirkham
+    - jjhelmus
     - ocefpaf
     - pelson

--- a/recipe/run_conda_forge_build_setup_linux
+++ b/recipe/run_conda_forge_build_setup_linux
@@ -12,8 +12,5 @@ conda config --set add_pip_as_python_dependency false
 conda update -n root --yes --quiet conda conda-env conda-build
 conda install -n root --yes --quiet jinja2 anaconda-client
 
-# KLUDGE to work around changes in conda-build 2.0.0
-conda install -n root --yes --quiet conda-build=1
-
 conda info
 conda config --get

--- a/recipe/run_conda_forge_build_setup_osx
+++ b/recipe/run_conda_forge_build_setup_osx
@@ -12,8 +12,5 @@ conda config --set add_pip_as_python_dependency false
 conda update -n root --yes --quiet conda conda-env conda-build
 conda install -n root --yes --quiet jinja2 conda-build anaconda-client
 
-# KLUDGE to work around changes in conda-build 2.0.0
-conda install -n root --yes --quiet conda-build=1
-
 conda info
 conda config --get

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -11,8 +11,5 @@ conda config --set add_pip_as_python_dependency false
 conda update -n root --yes --quiet conda conda-env conda-build
 conda install -n root --yes --quiet jinja2 conda-build anaconda-client
 
-:: KLUDGE to work around changes in conda-build 2.0.0
-conda install -n root --yes --quiet conda-build=1
-
 conda info
 conda config --get


### PR DESCRIPTION
Remove pinning of conda-build to version 1.x.

Increment version to 4.0.0 to indicate significant change to a new major version of conda-build.