### PR TITLE
Set the conda-build working directory 

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-forge-build-setup
-  version: 4.2.0
+  version: 4.3.0
 
 build:
   number: 0

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -16,5 +16,8 @@ conda install -n root --yes --quiet jinja2 conda-build anaconda-client
 conda install -n root --yes --quiet vs2008_express_vc_python_patch
 call setup_x64
 
+:: Set the conda-build working directory to a smaller path
+set "CONDA_BLD_PATH=C:\\bld\\"
+
 conda info
 conda config --get


### PR DESCRIPTION
Closes https://github.com/conda-forge/conda-smithy/pull/419

This changes the longer path in conda-build 2.x to a shorter path so that
boost (and possibly others) doesn't hit Windows' path size limit.