### PR TITLE
Fast finish CIs script

### DIFF
--- a/recipe/ff_ci_pr_build.py
+++ b/recipe/ff_ci_pr_build.py
@@ -82,6 +82,31 @@ def travis_check_latest_pr_build(repo, pr, build_num):
         return True
 
 
+def appveyor_check_latest_pr_build(repo, pr, build_num, total_builds=50):
+    # Not a PR so it is latest.
+    if pr is None:
+        return True
+
+    headers = {
+        "Accept": "application/json",
+    }
+    url = "https://ci.appveyor.com/api/projects/{repo}/history?recordsNumber={total_builds}"
+
+    data = request_json(url.format(repo=repo, total_builds=total_builds), headers=headers)
+
+    # Parse the response to get a list of build numbers for this PR.
+    builds = data["builds"]
+    pr_builds = filter(lambda b: b.get("pullRequestId", "") == str(pr), builds)
+    pr_build_nums = sorted(map(lambda b: int(b["buildNumber"]), pr_builds))
+
+    # Check if our build number is the latest (largest)
+    # out of all of the builds for this PR.
+    if build_num < max(pr_build_nums):
+        return False
+    else:
+        return True
+
+
 def main(*args):
     if not args:
         args = sys.argv[1:]
@@ -101,6 +126,7 @@ def main(*args):
         choices=[
             "circle",
             "travis",
+            "appveyor",
         ],
         help="Which CI to check for an outdated build",
     )
@@ -139,6 +165,8 @@ def main(*args):
         exit_code = int(circle_check_latest_pr_build(repo, pr, bld) is False)
     elif ci == "travis":
         exit_code = int(travis_check_latest_pr_build(repo, pr, bld) is False)
+    elif ci == "appveyor":
+        exit_code = int(appveyor_check_latest_pr_build(repo, pr, bld) is False)
 
     if verbose and exit_code == 1:
         print("Failing outdated PR build to end it.")

--- a/recipe/ff_ci_pr_build.py
+++ b/recipe/ff_ci_pr_build.py
@@ -1,5 +1,19 @@
 #!/usr/bin/env python
 
+"""
+Fast finish old PR builds on CIs
+
+Using various CI's (CircleCI, Travis CI, and AppVeyor) APIs and information
+about the current build for the relevant CI, this script checks to see if the
+current PR build is the most recent one. It does this by comparing the current
+PR build's build number to other build numbers of builds for this PR. If it is
+not the most recent build for the PR, then this script exits with a failure.
+Thus it can fail the build; stopping it from proceeding further. However, if
+it is the most recent build number or if it is not a PR (e.g. a build on a
+normal branch), then the build proceeds without issues.
+"""
+
+
 try:
     from future_builtins import (
         map,
@@ -112,7 +126,7 @@ def main(*args):
         args = sys.argv[1:]
 
     parser = argparse.ArgumentParser(
-        description="Determine whether this build should end."
+        description=__doc__.strip().splitlines()[0]
     )
     parser.add_argument(
         "-v",

--- a/recipe/ff_ci_pr_build.py
+++ b/recipe/ff_ci_pr_build.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python
+
+try:
+    from future_builtins import (
+        map,
+        filter,
+    )
+except ImportError:
+    pass
+
+import argparse
+import codecs
+import contextlib
+import json
+import os
+import sys
+
+try:
+    from urllib.request import (
+        Request,
+        urlopen,
+    )
+except ImportError:
+    from urllib2 import (
+        Request,
+        urlopen,
+    )
+
+
+def request_json(url, headers={}):
+    request = Request(url, headers=headers)
+    with contextlib.closing(urlopen(request)) as response:
+        reader = codecs.getreader("utf-8")
+        return json.load(reader(response))
+
+
+def circle_check_latest_pr_build(repo, pr, build_num):
+    # Not a PR so it is latest.
+    if pr is None:
+        return True
+
+    headers = {
+        "Accept": "application/json",
+    }
+    url = "https://circleci.com/api/v1.1/project/github/{repo}/tree/pull/{pr}"
+
+    builds = request_json(url.format(repo=repo, pr=pr), headers=headers)
+
+    # Parse the response to get a list of build numbers for this PR.
+    pr_build_nums = sorted(map(lambda b: int(b["build_num"]), builds))
+
+    # Check if our build number is the latest (largest)
+    # out of all of the builds for this PR.
+    if build_num < max(pr_build_nums):
+        return False
+    else:
+        return True
+
+
+def main(*args):
+    if not args:
+        args = sys.argv[1:]
+
+    parser = argparse.ArgumentParser(
+        description="Determine whether this build should end."
+    )
+    parser.add_argument(
+        "-v",
+        "--verbose",
+        action="store_true",
+        help="Whether to include output",
+    )
+    parser.add_argument(
+        "--ci",
+        required=True,
+        choices=[
+            "circle",
+        ],
+        help="Which CI to check for an outdated build",
+    )
+    parser.add_argument(
+        "repo",
+        type=str,
+        help="GitHub repo name (e.g. `user/repo`.)",
+    )
+    parser.add_argument(
+        "bld",
+        type=int,
+        help="CI build number for this pull request",
+    )
+    parser.add_argument(
+        "pr",
+        nargs="?",
+        default="",
+        help="GitHub pull request number of this build",
+    )
+
+    params = parser.parse_args(args)
+    verbose = params.verbose
+    ci = params.ci
+    repo = params.repo
+    bld = params.bld
+    try:
+        pr = int(params.pr)
+    except ValueError:
+        pr = None
+
+    if verbose:
+        print("Checking to see if this PR build is outdated.")
+
+    exit_code = 0
+    if ci == "circle":
+        exit_code = int(circle_check_latest_pr_build(repo, pr, bld) is False)
+
+    if verbose and exit_code == 1:
+        print("Failing outdated PR build to end it.")
+
+    return exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,6 +10,8 @@ build:
     - COPY "%RECIPE_DIR%\\run_conda_forge_build_setup_win.bat" "%SCRIPTS%\\run_conda_forge_build_setup.bat"              # [win]
     - cp "${RECIPE_DIR}/run_conda_forge_build_setup_osx" "${PREFIX}/bin/run_conda_forge_build_setup"                     # [osx]
     - cp "${RECIPE_DIR}/run_conda_forge_build_setup_linux" "${PREFIX}/bin/run_conda_forge_build_setup"                   # [linux]
+    - COPY "%RECIPE_DIR%\\ff_ci_pr_build.py" "%SCRIPTS%\\ff_ci_pr_build.py"                                              # [win]
+    - cp "${RECIPE_DIR}/ff_ci_pr_build.py" "${PREFIX}/bin/ff_ci_pr_build"                                                # [unix]
     - COPY "%RECIPE_DIR%\\upload_or_check_non_existence.py" "%SCRIPTS%\\upload_or_check_non_existence.py"                # [win]
     - cp "${RECIPE_DIR}/upload_or_check_non_existence.py" "${PREFIX}/bin/upload_or_check_non_existence"                  # [unix]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -19,6 +19,8 @@ test:
   commands:
     - if not exist "%SCRIPTS%\\run_conda_forge_build_setup.bat" exit 1                                                   # [win]
     - test -f "${PREFIX}/bin/run_conda_forge_build_setup"                                                                # [unix]
+    - if not exist "%SCRIPTS%\\ff_ci_pr_build.py" exit 1                                                                 # [win]
+    - test -f "${PREFIX}/bin/ff_ci_pr_build"                                                                             # [unix]
     - if not exist "%SCRIPTS%\\upload_or_check_non_existence.py" exit 1                                                  # [win]
     - test -f "${PREFIX}/bin/upload_or_check_non_existence"                                                              # [unix]
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-forge-build-setup
-  version: 4.3.0
+  version: 4.4.0
 
 build:
   number: 0


### PR DESCRIPTION
This adds a script for fast finish CI builds. The script is designed to work on CircleCI, Travis CI, and AppVeyor. It checks to see if the current build has the highest build ID (number) out of all builds for the PR. If it doesn't have the highest build ID, then the job errors itself out. If it does have the highest build number or is not a PR, the job proceeds without issues.