### PR TITLE
Add core as maintainers

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,5 +29,9 @@ extra:
   recipe-maintainers:
     - jakirkham
     - jjhelmus
+    - msarahan
+    - mwcraig
     - ocefpaf
+    - patricksnape
     - pelson
+    - scopatz


### PR DESCRIPTION
This explicitly adds all of @conda-forge/core as maintainers of `conda-forge-build-setup`. As this determines how all of the CIs at conda-forge are setup, it is paramount that all of core explicitly has access should they need it. This provides that access.