### PR TITLE
Handle potentially empty collection of builds

### DIFF
--- a/recipe/ff_ci_pr_build.py
+++ b/recipe/ff_ci_pr_build.py
@@ -61,7 +61,7 @@ def circle_check_latest_pr_build(repo, pr, build_num):
     builds = request_json(url.format(repo=repo, pr=pr), headers=headers)
 
     # Parse the response to get a list of build numbers for this PR.
-    pr_build_nums = sorted(map(lambda b: int(b["build_num"]), builds))
+    pr_build_nums = set(map(lambda b: int(b["build_num"]), builds))
 
     # Check if our build number is the latest (largest)
     # out of all of the builds for this PR.
@@ -86,7 +86,7 @@ def travis_check_latest_pr_build(repo, pr, build_num):
     # Parse the response to get a list of build numbers for this PR.
     builds = data["builds"]
     pr_builds = filter(lambda b: b["pull_request_number"] == pr, builds)
-    pr_build_nums = sorted(map(lambda b: int(b["number"]), pr_builds))
+    pr_build_nums = set(map(lambda b: int(b["number"]), pr_builds))
 
     # Check if our build number is the latest (largest)
     # out of all of the builds for this PR.
@@ -111,7 +111,7 @@ def appveyor_check_latest_pr_build(repo, pr, build_num, total_builds=50):
     # Parse the response to get a list of build numbers for this PR.
     builds = data["builds"]
     pr_builds = filter(lambda b: b.get("pullRequestId", "") == str(pr), builds)
-    pr_build_nums = sorted(map(lambda b: int(b["buildNumber"]), pr_builds))
+    pr_build_nums = set(map(lambda b: int(b["buildNumber"]), pr_builds))
 
     # Check if our build number is the latest (largest)
     # out of all of the builds for this PR.

--- a/recipe/ff_ci_pr_build.py
+++ b/recipe/ff_ci_pr_build.py
@@ -62,6 +62,7 @@ def circle_check_latest_pr_build(repo, pr, build_num):
 
     # Parse the response to get a list of build numbers for this PR.
     pr_build_nums = set(map(lambda b: int(b["build_num"]), builds))
+    pr_build_nums.add(build_num)
 
     # Check if our build number is the latest (largest)
     # out of all of the builds for this PR.
@@ -87,6 +88,7 @@ def travis_check_latest_pr_build(repo, pr, build_num):
     builds = data["builds"]
     pr_builds = filter(lambda b: b["pull_request_number"] == pr, builds)
     pr_build_nums = set(map(lambda b: int(b["number"]), pr_builds))
+    pr_build_nums.add(build_num)
 
     # Check if our build number is the latest (largest)
     # out of all of the builds for this PR.
@@ -112,6 +114,7 @@ def appveyor_check_latest_pr_build(repo, pr, build_num, total_builds=50):
     builds = data["builds"]
     pr_builds = filter(lambda b: b.get("pullRequestId", "") == str(pr), builds)
     pr_build_nums = set(map(lambda b: int(b["buildNumber"]), pr_builds))
+    pr_build_nums.add(build_num)
 
     # Check if our build number is the latest (largest)
     # out of all of the builds for this PR.

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-forge-build-setup
-  version: 4.4.0
+  version: 4.4.1
 
 build:
   number: 0


### PR DESCRIPTION
Fixes https://github.com/conda-forge/conda-forge-build-setup-feedstock/issues/57
Fixes https://github.com/conda-forge/staged-recipes/issues/2498 (added in edit)

We have seen at least one case where the Travis CI API return no builds matching a particular PR number. When this occurs, an empty collection is passed to `max`, which results in a crash that fails the build. While we have no idea why, we still don't want to block builds due to a bug from completing in this case.

Here we add a workaround, which simply ensures the current build number is included in our collection of builds matching this PR even if the collection was previously empty. This way we can guarantee the collection of builds is not empty and includes the bare minimum we expect (the current build). Also if the collection was empty, we guarantee that the current build will proceed unhindered. We go ahead and implement this measure for the other CIs as well even if we have not encountered (or are unaware of encountering) similar issues with them.

cc @rolando