### PR TITLE
Increase travis CPU_COUNT to 2

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-forge-build-setup
-  version: 4.4.2
+  version: 4.4.3
 
 build:
   number: 0

--- a/recipe/run_conda_forge_build_setup_osx
+++ b/recipe/run_conda_forge_build_setup_osx
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-# 1 core available on Travis CI OS X workers: https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments
+# 2 core available on Travis CI OS X workers: https://docs.travis-ci.com/user/ci-environment/#Virtualization-environments
 # CPU_COUNT is passed through conda build: https://github.com/conda/conda-build/pull/1149
-export CPU_COUNT=1
+export CPU_COUNT=2
 
 export PYTHONUNBUFFERED=1
 


### PR DESCRIPTION
Fix #62 

This is necessary to build https://github.com/conda-forge/llvmdev-feedstock/pull/19 because llvm 4.0 is taking much longer to build