### PR TITLE
Unpin conda-build

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-forge-build-setup
-  version: 4.4.3
+  version: 4.4.4
 
 build:
   number: 0

--- a/recipe/run_conda_forge_build_setup_linux
+++ b/recipe/run_conda_forge_build_setup_linux
@@ -11,7 +11,6 @@ conda config --set add_pip_as_python_dependency false
 
 conda update -n root --yes --quiet conda conda-env conda-build
 conda install -n root --yes --quiet jinja2 anaconda-client
-conda install -n root --yes --quiet conda-build=2.1.4
 
 conda info
 conda config --get

--- a/recipe/run_conda_forge_build_setup_linux
+++ b/recipe/run_conda_forge_build_setup_linux
@@ -10,7 +10,7 @@ conda config --set show_channel_urls true
 conda config --set add_pip_as_python_dependency false
 
 conda update -n root --yes --quiet conda conda-env conda-build
-conda install -n root --yes --quiet jinja2 anaconda-client
+conda install -n root --yes --quiet conda-build jinja2 anaconda-client
 
 conda info
 conda config --get

--- a/recipe/run_conda_forge_build_setup_osx
+++ b/recipe/run_conda_forge_build_setup_osx
@@ -12,7 +12,7 @@ conda config --set show_channel_urls true
 conda config --set add_pip_as_python_dependency false
 
 conda update -n root --yes --quiet conda conda-env conda-build
-conda install -n root --yes --quiet jinja2 anaconda-client
+conda install -n root --yes --quiet conda-build jinja2 anaconda-client
 
 conda info
 conda config --get

--- a/recipe/run_conda_forge_build_setup_osx
+++ b/recipe/run_conda_forge_build_setup_osx
@@ -13,7 +13,6 @@ conda config --set add_pip_as_python_dependency false
 
 conda update -n root --yes --quiet conda conda-env conda-build
 conda install -n root --yes --quiet jinja2 anaconda-client
-conda install -n root --yes --quiet conda-build=2.1.4
 
 conda info
 conda config --get

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -10,7 +10,6 @@ conda config --set add_pip_as_python_dependency false
 
 conda update -n root --yes --quiet conda conda-env conda-build
 conda install -n root --yes --quiet jinja2 anaconda-client
-conda install -n root --yes --quiet conda-build=2.1.4
 
 :: Needed for building extensions in python2.7 x64 with cmake.
 :: Since python version and arch is not known at this point, install it everywhere.

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -9,7 +9,7 @@ conda config --set show_channel_urls true
 conda config --set add_pip_as_python_dependency false
 
 conda update -n root --yes --quiet conda conda-env conda-build
-conda install -n root --yes --quiet jinja2 anaconda-client
+conda install -n root --yes --quiet conda-build jinja2 anaconda-client
 
 :: Needed for building extensions in python2.7 x64 with cmake.
 :: Since python version and arch is not known at this point, install it everywhere.


### PR DESCRIPTION
Reverts the pinning of `conda-build` to 2.1.4 as done in PR ( https://github.com/conda-forge/conda-forge-build-setup-feedstock/pull/61 ). As we recently packaged `conda-build` 2.1.8, which fixes the bugs experienced, we should be fine to drop this pinning. It also contains some useful fixes.

cc @conda-forge/core