### PR TITLE
Pin conda-build to 2.x

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-forge-build-setup
-  version: 4.4.7
+  version: 4.4.8
 
 build:
   number: 0

--- a/recipe/run_conda_forge_build_setup_linux
+++ b/recipe/run_conda_forge_build_setup_linux
@@ -11,7 +11,8 @@ conda config --set auto_update_conda false
 conda config --set add_pip_as_python_dependency false
 
 conda update -n root --yes --quiet conda conda-env conda-build
-conda install -n root --yes --quiet conda-build jinja2 anaconda-client
+conda install -n root --yes --quiet jinja2 anaconda-client
+conda install -n root --yes --quiet conda-build=2
 
 conda info
 conda config --get

--- a/recipe/run_conda_forge_build_setup_osx
+++ b/recipe/run_conda_forge_build_setup_osx
@@ -13,7 +13,8 @@ conda config --set auto_update_conda false
 conda config --set add_pip_as_python_dependency false
 
 conda update -n root --yes --quiet conda conda-env conda-build
-conda install -n root --yes --quiet conda-build jinja2 anaconda-client
+conda install -n root --yes --quiet jinja2 anaconda-client
+conda install -n root --yes --quiet conda-build=2
 
 conda info
 conda config --get

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -10,7 +10,8 @@ conda config --set auto_update_conda false
 conda config --set add_pip_as_python_dependency false
 
 conda update -n root --yes --quiet conda conda-env conda-build
-conda install -n root --yes --quiet conda-build jinja2 anaconda-client
+conda install -n root --yes --quiet jinja2 anaconda-client
+conda install -n root --yes --quiet conda-build=2
 
 :: Needed for building extensions in python2.7 x64 with cmake.
 :: Since python version and arch is not known at this point, install it everywhere.


### PR DESCRIPTION
Temporarily pins `conda-build` 2.x until we have some time to test and verify it will work at conda-forge.

cc @conda-forge/core