### PR TITLE
Pin conda 4.2.13 on Windows

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-forge-build-setup
-  version: 4.4.5
+  version: 4.4.6
 
 build:
   number: 0

--- a/recipe/run_conda_forge_build_setup_linux
+++ b/recipe/run_conda_forge_build_setup_linux
@@ -7,6 +7,7 @@ export CPU_COUNT=2
 export PYTHONUNBUFFERED=1
 
 conda config --set show_channel_urls true
+conda config --set auto_update_conda false
 conda config --set add_pip_as_python_dependency false
 
 conda update -n root --yes --quiet conda conda-env conda-build

--- a/recipe/run_conda_forge_build_setup_osx
+++ b/recipe/run_conda_forge_build_setup_osx
@@ -9,6 +9,7 @@ export PYTHONUNBUFFERED=1
 export MACOSX_DEPLOYMENT_TARGET="10.9"
 
 conda config --set show_channel_urls true
+conda config --set auto_update_conda false
 conda config --set add_pip_as_python_dependency false
 
 conda update -n root --yes --quiet conda conda-env conda-build

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -6,6 +6,7 @@ set CPU_COUNT=2
 set PYTHONUNBUFFERED=1
 
 conda config --set show_channel_urls true
+conda config --set auto_update_conda false
 conda config --set add_pip_as_python_dependency false
 
 conda update -n root --yes --quiet conda conda-env conda-build

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -9,7 +9,7 @@ conda config --set show_channel_urls true
 conda config --set auto_update_conda false
 conda config --set add_pip_as_python_dependency false
 
-conda update -n root --yes --quiet conda conda-env conda-build
+conda install -n root --yes --quiet conda=4.2.13 conda-env
 conda install -n root --yes --quiet conda-build jinja2 anaconda-client
 
 :: Needed for building extensions in python2.7 x64 with cmake.


### PR DESCRIPTION
Pins Windows to the last known working version of `conda` 4.2.13 to workaround consistent failures that are occurring with `conda` 4.3.* on Windows builds during the test stage.

ref: https://ci.appveyor.com/project/conda-forge/pyarrow-feedstock
ref: https://ci.appveyor.com/project/conda-forge/sphinx-argparse-feedstock
ref: https://ci.appveyor.com/project/conda-forge/mppp-feedstock

(The list continues...)

