### PR TITLE
Unpin conda on Windows

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-forge-build-setup
-  version: 4.4.6
+  version: 4.4.7
 
 build:
   number: 0

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -9,7 +9,7 @@ conda config --set show_channel_urls true
 conda config --set auto_update_conda false
 conda config --set add_pip_as_python_dependency false
 
-conda install -n root --yes --quiet conda=4.2.13 conda-env
+conda update -n root --yes --quiet conda conda-env conda-build
 conda install -n root --yes --quiet conda-build jinja2 anaconda-client
 
 :: Needed for building extensions in python2.7 x64 with cmake.


### PR DESCRIPTION
Attempts to revert the `conda` pinning on Windows added in PR ( https://github.com/conda-forge/conda-forge-build-setup-feedstock/pull/70 ). This also acts as a test to see whether that pinning can be reverted. The hope is that releasing `conda-build` 2.1.15 into `conda-forge` has fixed the problem seen with `conda` 4.3 on Windows in the feedstocks.