### PR TITLE
Update AppVeyor VM core info link [skip ci]

### DIFF
--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -1,5 +1,5 @@
 
-:: 2 cores available on Appveyor workers: https://www.appveyor.com/docs/build-configuration/#build-environment
+:: 2 cores available on Appveyor workers: https://www.appveyor.com/docs/build-environment/#build-vm-configurations
 :: CPU_COUNT is passed through conda build: https://github.com/conda/conda-build/pull/1149
 set CPU_COUNT=2
 


### PR DESCRIPTION
AppVeyor VM's number of cores configuration has moved in the docs. This updates the link to be the new one shown below.

ref: https://www.appveyor.com/docs/build-environment/#build-vm-configurations