### PR TITLE
Unpin conda 4.3.22

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-forge-build-setup
-  version: 4.4.10
+  version: 4.4.11
 
 build:
   number: 0

--- a/recipe/run_conda_forge_build_setup_linux
+++ b/recipe/run_conda_forge_build_setup_linux
@@ -12,7 +12,7 @@ conda config --set add_pip_as_python_dependency false
 
 conda update -n root --yes --quiet conda conda-env conda-build
 conda install -n root --yes --quiet jinja2 anaconda-client
-conda install -n root --yes --quiet conda-build=2 conda=4.3.22
+conda install -n root --yes --quiet conda-build=2
 
 conda info
 conda config --get

--- a/recipe/run_conda_forge_build_setup_osx
+++ b/recipe/run_conda_forge_build_setup_osx
@@ -14,7 +14,7 @@ conda config --set add_pip_as_python_dependency false
 
 conda update -n root --yes --quiet conda conda-env conda-build
 conda install -n root --yes --quiet jinja2 anaconda-client
-conda install -n root --yes --quiet conda-build=2 conda=4.3.22
+conda install -n root --yes --quiet conda-build=2
 
 conda info
 conda config --get

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -11,7 +11,7 @@ conda config --set add_pip_as_python_dependency false
 
 conda update -n root --yes --quiet conda conda-env conda-build
 conda install -n root --yes --quiet jinja2 anaconda-client
-conda install -n root --yes --quiet conda-build=2 conda=4.3.22
+conda install -n root --yes --quiet conda-build=2
 
 :: Needed for building extensions in python2.7 x64 with cmake.
 :: Since python version and arch is not known at this point, install it everywhere.


### PR DESCRIPTION
Now that `conda-build-all` supports `conda` 4.3.23, we should no longer need to pin `conda`.