### PR TITLE
Support noarch in upload_or_check_non_existence.py

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-forge-build-setup
-  version: 4.4.11
+  version: 4.4.12
 
 build:
   number: 0

--- a/recipe/upload_or_check_non_existence.py
+++ b/recipe/upload_or_check_non_existence.py
@@ -22,7 +22,9 @@ def built_distribution_already_exists(cli, meta, owner):
     exists on the owner/user's binstar account.
 
     """
-    distro_name = '{}/{}.tar.bz2'.format(conda.config.subdir, meta.dist())
+    plat = conda.config.subdir if meta.config.platform != 'noarch' else 'noarch'
+    distro_name = '{}/{}.tar.bz2'.format(plat, meta.dist())
+
     try:
         config = Config()
         fname = bldpkg_path(meta, config)


### PR DESCRIPTION
Fixes #80 

@msarahan, is there a better way to get the platform for the built distribution?