### PR TITLE
Write token to a temporary directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ To manage the continuous integration and simplify feedstock maintenance
 Using the ``conda-forge.yml`` within this repository, it is possible to re-render all of
 this feedstock's supporting files (e.g. the CI configuration files) with ``conda smithy rerender``.
 
+For more information please check the [conda-forge documentation](https://conda-forge.org/docs/).
 
 Terminology
 ===========

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -33,18 +33,18 @@ install:
 
     # Add path, activate `conda` and update conda.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
-    - cmd: conda update --yes --quiet conda
+    - cmd: conda.exe update --yes --quiet conda
 
     - cmd: set PYTHONUNBUFFERED=1
 
     # Add our channels.
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda config --remove channels defaults
-    - cmd: conda config --add channels defaults
-    - cmd: conda config --add channels conda-forge
+    - cmd: conda.exe config --set show_channel_urls true
+    - cmd: conda.exe config --remove channels defaults
+    - cmd: conda.exe config --add channels defaults
+    - cmd: conda.exe config --add channels conda-forge
 
     # Configure the VM.
-    - cmd: conda install -n root --quiet --yes conda-forge-build-setup
+    - cmd: conda.exe install -n root --quiet --yes conda-forge-build-setup
     # Overriding global conda-forge-build-setup with local copy.
     - cmd: recipe\run_conda_forge_build_setup_win
 
@@ -52,6 +52,6 @@ install:
 build: off
 
 test_script:
-    - conda build recipe --quiet
+    - conda.exe build recipe --quiet
 deploy_script:
     - cmd: recipe\upload_or_check_non_existence .\recipe conda-forge --channel=main

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-forge-build-setup
-  version: 4.4.14
+  version: 4.4.15
 
 build:
   number: 0

--- a/recipe/upload_or_check_non_existence.py
+++ b/recipe/upload_or_check_non_existence.py
@@ -6,6 +6,7 @@ import hashlib
 import os
 import subprocess
 import sys
+import tempfile
 
 from binstar_client.utils import get_binstar
 import binstar_client.errors
@@ -54,16 +55,14 @@ def built_distribution_already_exists(cli, meta, owner):
 
 
 def upload(cli, meta, owner, channels):
-    try:
-        with open('binstar.token', 'w') as fh:
-            fh.write(cli.token)
-        subprocess.check_call(['anaconda', '--quiet', '-t', 'binstar.token',
+    with tempfile.NamedTemporaryFile(mode="w", prefix="binstar_", suffix=".token") as fh:
+        fh.write(cli.token)
+        fh.flush()
+        subprocess.check_call(['anaconda', '--quiet', '-t', fh.name,
                                'upload', bldpkg_path(meta),
                                '--user={}'.format(owner),
                                '--channel={}'.format(channels)],
                               env=os.environ)
-    finally:
-        os.remove('binstar.token')
 
 
 def distribution_exists_on_channel(binstar_cli, meta, owner, channel='main'):


### PR DESCRIPTION
Simplifies the cleanup steps involved with writing and getting rid of the token. Also has the bonus of being somewhere that is writable given the lock down of Docker permissions. ( https://github.com/conda-forge/docker-images/pull/39 )
  