### PR TITLE
Improve temporary token

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-forge-build-setup
-  version: 4.4.15
+  version: 4.4.16
 
 build:
   number: 0


### PR DESCRIPTION
Follow-up to PR ( https://github.com/conda-forge/conda-forge-build-setup-feedstock/pull/85 )

Makes sure to close the temporary file before it is read by `anaconda-client` to avoid issues on Windows.
  