### PR TITLE
Use newer anaconda-client API

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-forge-build-setup
-  version: 4.4.19
+  version: 4.4.20
 
 build:
   number: 0

--- a/recipe/upload_or_check_non_existence.py
+++ b/recipe/upload_or_check_non_existence.py
@@ -10,7 +10,7 @@ import subprocess
 import sys
 import tempfile
 
-from binstar_client.utils import get_binstar
+from binstar_client.utils import get_server_api
 import binstar_client.errors
 import conda.config
 from conda.api import get_index
@@ -111,7 +111,7 @@ def main():
     args = parser.parse_args()
     recipe_dir, owner, channel = args.recipe_dir, args.owner, args.channel
 
-    cli = get_binstar(argparse.Namespace(token=token, site=None))
+    cli = get_server_api(token=token)
     meta_main = MetaData(recipe_dir)
     for _, meta in meta_main.get_output_metadata_set(files=None):
         print("Processing {}".format(meta.name()))


### PR DESCRIPTION
Seems `get_binstar` has been deprecated for a while (and recently removed). This switches us over to the newer, preferred `get_server_api`.

xref: https://github.com/Anaconda-Platform/anaconda-client/issues/463
xref: https://github.com/conda-forge/conda-forge-ci-setup-feedstock/pull/8 (forwardport)