### PR TITLE
pin conda version in setup

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -10,12 +10,12 @@ environment:
 
   matrix:
     - TARGET_ARCH: x86
-      CONDA_PY: 27
-      CONDA_INSTALL_LOCN: C:\\Miniconda
+      CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
 
     - TARGET_ARCH: x64
-      CONDA_PY: 27
-      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
+      CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
 
 
 # We always use a 64-bit machine, but can build x86 distributions

--- a/recipe/run_conda_forge_build_setup_linux
+++ b/recipe/run_conda_forge_build_setup_linux
@@ -10,7 +10,7 @@ conda config --set show_channel_urls true
 conda config --set auto_update_conda false
 conda config --set add_pip_as_python_dependency false
 
-conda install -n root --yes --quiet conda=4.3 conda-env conda-build=2 jinja2 anaconda-client
+conda install -n root --yes --quiet conda=4.3 conda-build=2 jinja2 anaconda-client
 
 conda info
 conda config --get

--- a/recipe/run_conda_forge_build_setup_linux
+++ b/recipe/run_conda_forge_build_setup_linux
@@ -10,9 +10,7 @@ conda config --set show_channel_urls true
 conda config --set auto_update_conda false
 conda config --set add_pip_as_python_dependency false
 
-conda update -n root --yes --quiet conda conda-env conda-build
-conda install -n root --yes --quiet jinja2 anaconda-client
-conda install -n root --yes --quiet conda-build=2
+conda install -n root --yes --quiet conda=4.3 conda-env conda-build=2 jinja2 anaconda-client
 
 conda info
 conda config --get

--- a/recipe/run_conda_forge_build_setup_osx
+++ b/recipe/run_conda_forge_build_setup_osx
@@ -12,7 +12,7 @@ conda config --set show_channel_urls true
 conda config --set auto_update_conda false
 conda config --set add_pip_as_python_dependency false
 
-conda install -n root --yes --quiet conda=4.3 conda-env conda-build=2 jinja2 anaconda-client
+conda install -n root --yes --quiet conda=4.3 conda-build=2 jinja2 anaconda-client
 
 conda info
 conda config --get

--- a/recipe/run_conda_forge_build_setup_osx
+++ b/recipe/run_conda_forge_build_setup_osx
@@ -12,7 +12,7 @@ conda config --set show_channel_urls true
 conda config --set auto_update_conda false
 conda config --set add_pip_as_python_dependency false
 
-conda update -n root --yes --quiet conda=4.3 conda-env conda-build=2 jinja2 anaconda-client
+conda install -n root --yes --quiet conda=4.3 conda-env conda-build=2 jinja2 anaconda-client
 
 conda info
 conda config --get

--- a/recipe/run_conda_forge_build_setup_osx
+++ b/recipe/run_conda_forge_build_setup_osx
@@ -12,9 +12,7 @@ conda config --set show_channel_urls true
 conda config --set auto_update_conda false
 conda config --set add_pip_as_python_dependency false
 
-conda update -n root --yes --quiet conda conda-env conda-build
-conda install -n root --yes --quiet jinja2 anaconda-client
-conda install -n root --yes --quiet conda-build=2
+conda update -n root --yes --quiet conda=4.3 conda-env conda-build=2 jinja2 anaconda-client
 
 conda info
 conda config --get

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -9,7 +9,7 @@ conda config --set show_channel_urls true
 conda config --set auto_update_conda false
 conda config --set add_pip_as_python_dependency false
 
-conda update -n root --yes --quiet conda=4.3 conda-env conda-build=2 jinja2 anaconda-client
+conda install -n root --yes --quiet conda=4.3 conda-env conda-build=2 jinja2 anaconda-client
 
 :: Needed for building extensions in python2.7 x64 with cmake.
 :: Since python version and arch is not known at this point, install it everywhere.

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -9,7 +9,7 @@ conda config --set show_channel_urls true
 conda config --set auto_update_conda false
 conda config --set add_pip_as_python_dependency false
 
-conda install -n root --yes --quiet conda=4.3 conda-env conda-build=2 jinja2 anaconda-client
+conda install -n root --yes --quiet conda=4.3 conda-build=2 jinja2 anaconda-client
 
 :: Needed for building extensions in python2.7 x64 with cmake.
 :: Since python version and arch is not known at this point, install it everywhere.

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -9,9 +9,7 @@ conda config --set show_channel_urls true
 conda config --set auto_update_conda false
 conda config --set add_pip_as_python_dependency false
 
-conda update -n root --yes --quiet conda conda-env conda-build
-conda install -n root --yes --quiet jinja2 anaconda-client
-conda install -n root --yes --quiet conda-build=2
+conda update -n root --yes --quiet conda=4.3 conda-env conda-build=2 jinja2 anaconda-client
 
 :: Needed for building extensions in python2.7 x64 with cmake.
 :: Since python version and arch is not known at this point, install it everywhere.


### PR DESCRIPTION
Attempt to pin `conda` version in the setup here, so that conda-forge could publish new versions of the `conda` package to avoid the problem of https://github.com/conda-forge/conda-feedstock/issues/43. I don't actually know what caused that, and I can't reproduce (https://github.com/conda-forge/conda-feedstock/issues/43#issuecomment-375142760), but it would generally be nice to be able to publish the latest versions of `conda` / `conda-build` on conda-forge for users without breaking our infrastructure.

I am not very knowledgeable about what breaks with newer `conda`, and don't entirely know how to go about testing. My understanding is:

- The upload script that every feedstock uses needs `conda` 4.3. This has been solved for the CB3 version of things (https://github.com/conda-forge/conda-forge-build-setup-feedstock/issues/83#issuecomment-367547046), but in the meantime this change should make things work on the feedstocks if a new `conda` version is published.
- Current versions of `conda-smithy` need `conda` 4.3.
  - Old builds of `conda-smithy` didn't pin a `conda` version and so might have to be labeled broken to avoid conda choosing to install them rather than downgrade `conda`.
  - The webservices repo / others probably also need some attention before publishing new `conda` versions.
  - Users installing `conda-smithy` locally might run into issues with downgrading:
    - That's already an issue for (I think) any fresh installs of miniconda/anaconda.
    - Relatively few people should have to install conda-smithy now that the bot can easily rerender.
    - When conda-smithy 3 is ready, this will hopefully no longer be an issue.
- `conda-build-all` also has some conda dependencies: https://github.com/conda-tools/conda-build-all/pull/96
  - I think only `staged-recipes` currently uses this? And it installs `conda-forge-build-setup`, so it should be okay here too, though maybe the staged-recipes script will need a bit of tweaking.
  - Going away in CB3-land, if I understand correctly.

I also don't know if there was a reason for having the install in multiple lines before, but I've checked on our Docker image at least that this currently gets appropriate versions of everything.