### PR TITLE
Use conda-build's conda interface

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-forge-build-setup
-  version: 4.4.21
+  version: 4.4.22
 
 build:
   number: 0

--- a/recipe/upload_or_check_non_existence.py
+++ b/recipe/upload_or_check_non_existence.py
@@ -12,7 +12,7 @@ import tempfile
 
 from binstar_client.utils import get_server_api
 import binstar_client.errors
-import conda.config
+from conda_build.conda_interface import subdir as conda_subdir
 from conda.api import get_index
 from conda_build.metadata import MetaData
 from conda_build.build import bldpkg_path
@@ -35,7 +35,7 @@ def built_distribution_already_exists(cli, meta, owner):
     exists on the owner/user's binstar account.
 
     """
-    plat = 'noarch' if meta.noarch else conda.config.subdir
+    plat = 'noarch' if meta.noarch else conda_subdir
     distro_name = '{}/{}.tar.bz2'.format(plat, meta.dist())
 
     try:
@@ -90,7 +90,7 @@ def distribution_exists_on_channel(binstar_cli, meta, owner, channel='main'):
 
     try:
         on_channel = (distributions_on_channel[fname]['subdir'] ==
-                      conda.config.subdir)
+                      conda_subdir)
     except KeyError:
         on_channel = False
 

--- a/recipe/upload_or_check_non_existence.py
+++ b/recipe/upload_or_check_non_existence.py
@@ -13,7 +13,7 @@ import tempfile
 from binstar_client.utils import get_server_api
 import binstar_client.errors
 from conda_build.conda_interface import subdir as conda_subdir
-from conda.api import get_index
+from conda_build.conda_interface import get_index
 from conda_build.metadata import MetaData
 from conda_build.build import bldpkg_path
 from conda_build.config import Config


### PR DESCRIPTION
Grab a few things we were grabbing from `conda` from `conda_build.conda_interface` instead. This should smooth over any remaining issues between `conda` 4.3 and 4.4+.