### PR TITLE
(Backport of) Use conda config show sources

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: conda-forge-build-setup
-  version: 4.4.22
+  version: 4.4.23
 
 build:
   number: 0

--- a/recipe/run_conda_forge_build_setup_linux
+++ b/recipe/run_conda_forge_build_setup_linux
@@ -13,4 +13,4 @@ conda config --set add_pip_as_python_dependency false
 conda install -n root --yes --quiet conda=4.3 conda-build=2 jinja2 anaconda-client
 
 conda info
-conda config --get
+conda config --show-sources

--- a/recipe/run_conda_forge_build_setup_osx
+++ b/recipe/run_conda_forge_build_setup_osx
@@ -15,4 +15,4 @@ conda config --set add_pip_as_python_dependency false
 conda install -n root --yes --quiet conda=4.3 conda-build=2 jinja2 anaconda-client
 
 conda info
-conda config --get
+conda config --show-sources

--- a/recipe/run_conda_forge_build_setup_win.bat
+++ b/recipe/run_conda_forge_build_setup_win.bat
@@ -20,4 +20,4 @@ call setup_x64
 set "CONDA_BLD_PATH=C:\\bld\\"
 
 conda.exe info
-conda.exe config --get
+conda.exe config --show-sources


### PR DESCRIPTION
Backports PR ( https://github.com/conda-forge/conda-forge-ci-setup-feedstock/pull/11 ) to existing feedstocks.

Resolves https://github.com/conda-forge/conda-smithy/issues/748
Related to https://github.com/conda/conda/issues/7192

Instead of running `conda config --get`, switch to `conda config --show-sources`, which is the preferred way to inspect/provide in the log the contents of `.condarc`.

cc @isuruf @msarahan @kalefranz